### PR TITLE
Testimonials: Add Yena

### DIFF
--- a/src/assets/scss/components/_features.scss
+++ b/src/assets/scss/components/_features.scss
@@ -6,55 +6,57 @@
 
 /* Features */
 
-	.features {
-		@include vendor('display', 'flex');
-		@include vendor('flex-wrap', 'wrap');
-		@include vendor('justify-content', 'center');
-		width: calc(100% + #{_size(element-margin)});
-		margin: 0 0 (_size(element-margin) * 1.5) (_size(element-margin) * -1);
-		padding: 0;
-		list-style: none;
+.features {
+  @include vendor('display', 'flex');
+  @include vendor('flex-wrap', 'wrap');
+  @include vendor('justify-content', 'center');
+  width: calc(100% + #{_size(element-margin)});
+  margin: 0 0 (_size(element-margin) * 1.5) (_size(element-margin) * -1);
+  padding: 0;
+  list-style: none;
 
-		li {
-			width: calc(#{(100% / 3)} - #{_size(element-margin)});
-			margin-left: _size(element-margin);
-			margin-top: (_size(element-margin) * 1.5);
-			padding: 0;
+  li {
+    width: calc(#{(100% / 3)} - #{_size(element-margin)});
+    margin-left: _size(element-margin);
+    margin-top: (_size(element-margin) * 1.5);
+    padding: 0;
 
-			&:nth-child(1),
-			&:nth-child(2),
-			&:nth-child(3) {
-				margin-top: 0;
-			}
+    &:nth-child(1),
+    &:nth-child(2),
+    &:nth-child(3) {
+      margin-top: 0;
+    }
 
-			> :last-child {
-				margin-bottom: 0;
-			}
-		}
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
 
-		@include breakpoint(medium) {
-			li {
-				width: calc(#{(100% / 2)} - #{_size(element-margin)});
+  @include breakpoint(medium) {
+    li,
+    .two {
+      width: calc(#{(100% / 2)} - #{_size(element-margin)});
 
-				&:nth-child(3) {
-					margin-top: (_size(element-margin) * 1.5);
-				}
-			}
-		}
+      &:nth-child(3) {
+        margin-top: (_size(element-margin) * 1.5);
+      }
+    }
+  }
 
-		@include breakpoint(small) {
-			width: 100%;
-			margin: 0 0 _size(element-margin) 0;
+  @include breakpoint(small) {
+    width: 100%;
+    margin: 0 0 _size(element-margin) 0;
 
-			li {
-				width: 100%;
-				margin-left: 0;
-				margin-top: _size(element-margin);
+    li,
+    .two {
+      width: 100%;
+      margin-left: 0;
+      margin-top: _size(element-margin);
 
-				&:nth-child(2),
-				&:nth-child(3) {
-					margin-top: _size(element-margin);
-				}
-			}
-		}
-	}
+      &:nth-child(2),
+      &:nth-child(3) {
+        margin-top: _size(element-margin);
+      }
+    }
+  }
+}

--- a/src/assets/scss/components/_features.scss
+++ b/src/assets/scss/components/_features.scss
@@ -6,57 +6,55 @@
 
 /* Features */
 
-.features {
-  @include vendor('display', 'flex');
-  @include vendor('flex-wrap', 'wrap');
-  @include vendor('justify-content', 'center');
-  width: calc(100% + #{_size(element-margin)});
-  margin: 0 0 (_size(element-margin) * 1.5) (_size(element-margin) * -1);
-  padding: 0;
-  list-style: none;
+	.features {
+		@include vendor('display', 'flex');
+		@include vendor('flex-wrap', 'wrap');
+		@include vendor('justify-content', 'center');
+		width: calc(100% + #{_size(element-margin)});
+		margin: 0 0 (_size(element-margin) * 1.5) (_size(element-margin) * -1);
+		padding: 0;
+		list-style: none;
 
-  li {
-    width: calc(#{(100% / 3)} - #{_size(element-margin)});
-    margin-left: _size(element-margin);
-    margin-top: (_size(element-margin) * 1.5);
-    padding: 0;
+		li {
+			width: calc(#{(100% / 3)} - #{_size(element-margin)});
+			margin-left: _size(element-margin);
+			margin-top: (_size(element-margin) * 1.5);
+			padding: 0;
 
-    &:nth-child(1),
-    &:nth-child(2),
-    &:nth-child(3) {
-      margin-top: 0;
-    }
+			&:nth-child(1),
+			&:nth-child(2),
+			&:nth-child(3) {
+				margin-top: 0;
+			}
 
-    > :last-child {
-      margin-bottom: 0;
-    }
-  }
+			> :last-child {
+				margin-bottom: 0;
+			}
+		}
 
-  @include breakpoint(medium) {
-    li,
-    .two {
-      width: calc(#{(100% / 2)} - #{_size(element-margin)});
+		@include breakpoint(medium) {
+			li {
+				width: calc(#{(100% / 2)} - #{_size(element-margin)});
 
-      &:nth-child(3) {
-        margin-top: (_size(element-margin) * 1.5);
-      }
-    }
-  }
+				&:nth-child(3) {
+					margin-top: (_size(element-margin) * 1.5);
+				}
+			}
+		}
 
-  @include breakpoint(small) {
-    width: 100%;
-    margin: 0 0 _size(element-margin) 0;
+		@include breakpoint(small) {
+			width: 100%;
+			margin: 0 0 _size(element-margin) 0;
 
-    li,
-    .two {
-      width: 100%;
-      margin-left: 0;
-      margin-top: _size(element-margin);
+			li {
+				width: 100%;
+				margin-left: 0;
+				margin-top: _size(element-margin);
 
-      &:nth-child(2),
-      &:nth-child(3) {
-        margin-top: _size(element-margin);
-      }
-    }
-  }
-}
+				&:nth-child(2),
+				&:nth-child(3) {
+					margin-top: _size(element-margin);
+				}
+			}
+		}
+	}

--- a/src/assets/scss/components/_testimonials.scss
+++ b/src/assets/scss/components/_testimonials.scss
@@ -1,10 +1,26 @@
-        #testimonials {
-            p {
-                margin-bottom: 1em
-            }
+#testimonials {
+  p {
+    margin-bottom: 1em;
+  }
 
-            p span {
-                color: _palette(accent2);
-                font-weight: 400;
-            }
-        }
+  p span {
+    color: _palette(accent2);
+    font-weight: 400;
+  }
+
+  .two {
+    width: calc(#{(100% / 2.2)} - #{_size(element-margin)});
+  }
+
+  @include breakpoint(medium) {
+    .two {
+      width: 100%;
+    }
+  }
+
+  @include breakpoint(small) {
+    .two {
+      width: 100%;
+    }
+  }
+}

--- a/src/components/Testimonials.js
+++ b/src/components/Testimonials.js
@@ -9,33 +9,61 @@ const Testimonials = props => (
     <ul className="features">
       <li>
         <p>
-          "....Taylor & Gaby were harder on me than the actual recruiter, so by the
-          time I had the conversation I was so nervous about, I was so ready..."
-        </p>
-        <i className="name">Yanare, Software Engineer II</i>
-      </li>
-      <li>
-        <p>
-          "The negotiation process was very difficult and slightly confusing, but I was happy to have Gaby to turn to. She helped me evaluate two offers I was torn between and <span>gave me the confidence to continue forward</span> with my decision, and even ask for a <span>$10K signing bonus!</span>"
-        </p>
-        <i className="name">Vanessa, Full-Stack/UI Engineer</i>
-      </li>
-      <li>
-        <p>
-          "....Taylor & Gaby were harder on me than the actual recruiter, so by the
-          time I had the conversation I was so nervous about, I was so ready..."
-        </p>
-        <i className="name">Another person</i>
-      </li>
-      <li>
-        <p>
-          "Gaby and Taylor gave me the confidence I needed to negotiate my first job offer in tech! Through their workshop, I learned how to navigate my first offer and successfully ask for more. I negotiated a <span>X% increase over my initial offer</span> and it would not have been possible without Gaby and Taylor! <span>I’m so happy they gave me the guidance I needed!</span>"
+          "Gaby and Taylor gave me the confidence I needed to negotiate my first
+          job offer in tech! Through their workshop, I learned how to navigate
+          my first offer and successfully ask for more. I negotiated a &nbsp;
+          <span>X% increase over my initial offer</span> and it would not have
+          been possible without Gaby and Taylor! &nbsp;
+          <span>I’m so happy they gave me the guidance I needed!</span>"
         </p>
         <i className="name">Michelle, Support Engineer</i>
       </li>
       <li>
         <p>
-          "The idea of negotiating was very scary and overwhelming, but Taylor made the process manageable. She patiently and thoroughly helped me shore up my weaknesses and taught me techniques to <span>prepare for every possible outcome</span>. I really appreciated the methodical way she lowered my anxiety. In the end, I successfully negotiated <span>$5K more in base salary and a $10K signing bonus.</span>"
+          "The negotiation process was very difficult and slightly confusing,
+          but I was happy to have Gaby to turn to. She helped me evaluate two
+          offers I was torn between and &nbsp;
+          <span>gave me the confidence to continue forward</span> with my
+          decision, and even ask for a <span>$10K signing bonus!</span>"
+        </p>
+        <i className="name">Vanessa, Full-Stack/UI Engineer</i>
+      </li>
+      <li>
+        <p>
+          "....Taylor & Gaby were harder on me than the actual recruiter, so by
+          the time I had the conversation I was so nervous about, I was so
+          ready..."
+        </p>
+        <i className="name">Another person</i>
+      </li>
+      <li className="two">
+        <p>
+          “I’d spent all this time perfecting the art of the interview, but when
+          it came to negotiation, I’d never done it before and the mere idea of
+          it would send me into a burst of nervous laughter. Taylor and Gaby
+          &nbsp;
+          <span>armed me with concrete data, tips, and scripts</span> detailing
+          what to say at each step in the process from that initial phone screen
+          with a recruiter to working out that final compensation package. I
+          went from too scared to even think about negotiating to &nbsp;
+          <span>securing a $10k signing bonus right off the bat</span>. The
+          whole experience turned every fear and concern I had on its head and
+          &nbsp;
+          <span>I feel exceptionally confident</span> that when I need to
+          negotiate again in the future, <span>I’ll crush it.</span>”
+        </p>
+        <i className="name">Yanare, Software Engineer II</i>
+      </li>
+
+      <li className="two">
+        <p>
+          "The idea of negotiating was very scary and overwhelming, but Taylor
+          made the process manageable. She patiently and thoroughly helped me
+          shore up my weaknesses and taught me techniques to &nbsp;
+          <span>prepare for every possible outcome</span>. I really appreciated
+          the methodical way she lowered my anxiety. In the end, I successfully
+          negotiated &nbsp;
+          <span>$5K more in base salary and a $10K signing bonus.</span>"
         </p>
         <i className="name">Kristen, Full-Stack/UI Engineer</i>
       </li>


### PR DESCRIPTION
Add's Yena's testimonial, switch spots with Michelle's due to length

Also includes: 
- Prettier on files touched
- customize CSS for 2 testimonials format for second row (vs. 3)

BEFORE: 
<img width="469" alt="Screen Shot 2020-01-11 at 12 45 53 PM" src="https://user-images.githubusercontent.com/6733241/72210467-e4555300-3470-11ea-91d2-2469d7332c30.png">


AFTER:
<img width="726" alt="Screen Shot 2020-01-11 at 12 45 33 PM" src="https://user-images.githubusercontent.com/6733241/72210471-ea4b3400-3470-11ea-90a7-395555b65293.png">

and on smaller screen, goes to width 100% like others:
<img width="482" alt="Screen Shot 2020-01-11 at 12 47 17 PM" src="https://user-images.githubusercontent.com/6733241/72210476-f505c900-3470-11ea-8387-b3b1357bf5a9.png">



